### PR TITLE
Show all types, old and new, in count board

### DIFF
--- a/jobs/counts.rb
+++ b/jobs/counts.rb
@@ -3,6 +3,16 @@ require_relative 'include.rb'
 
 SCHEDULER.every '30s' do
   types = %w(
+    geoname
+    admin0
+    admin1
+    admin2
+    local_admin
+    neighborhood
+    openaddresses
+    osmnode
+    osmaddress
+    osmway
     address
     venue
     country


### PR DESCRIPTION
This will allow us to see the progress of the current prod_build build,
as well as make sure no old types are somewhow making into our new WOF
builds.
