### PR TITLE
Revert "Show all types, old and new, in count board"

### DIFF
--- a/jobs/counts.rb
+++ b/jobs/counts.rb
@@ -3,16 +3,6 @@ require_relative 'include.rb'
 
 SCHEDULER.every '30s' do
   types = %w(
-    geoname
-    admin0
-    admin1
-    admin2
-    local_admin
-    neighborhood
-    openaddresses
-    osmnode
-    osmaddress
-    osmway
     address
     venue
     country


### PR DESCRIPTION
Remove the old types, again, now that prod_build and dev are both using WOF.

This reverts commit ae755f56dcf09b9da441dbaf9697368fe16daf22.
