### PR TITLE
Dynamic ES index

### DIFF
--- a/jobs/counts.rb
+++ b/jobs/counts.rb
@@ -22,7 +22,7 @@ SCHEDULER.every '30s' do
   # get total
   total_url = URI.parse "#{@es_endpoint}/_stats/docs"
   total_response = JSON.parse Net::HTTP.get_response(total_url).body
-  total_count = as_val(total_response['indices']['pelias']['primaries']['docs']['count'])
+  total_count = as_val(total_response['indices'][@es_index]['primaries']['docs']['count'])
   types_counts['total'] = { label: 'total', value: total_count }
 
   # get types

--- a/jobs/es_metrics.rb
+++ b/jobs/es_metrics.rb
@@ -8,7 +8,7 @@ unless @expected_doc_count.nil?
   SCHEDULER.every '1m' do
     url = URI.parse "#{@es_endpoint}/_stats/docs"
     response = JSON.parse Net::HTTP.get_response(url).body
-    indexed = response['indices']['pelias']['primaries']['docs']['count']
+    indexed = response['indices'][@es_index]['primaries']['docs']['count']
 
     percent_complete = ((indexed.to_f / @expected_doc_count.to_f) * 100).to_i
     percent_complete > 100 ? percent_complete = 100 : percent_complete
@@ -22,10 +22,10 @@ SCHEDULER.every '1m' do
   url = URI.parse "#{@es_endpoint}/_stats?human"
   response = JSON.parse Net::HTTP.get_response(url).body
 
-  store_size = response['indices']['pelias']['primaries']['store']['size']
+  store_size = response['indices'][@es_index]['primaries']['store']['size']
   send_event('es-store-size', text: store_size)
 
-  completion_size = response['indices']['pelias']['primaries']['completion']['size']
+  completion_size = response['indices'][@es_index]['primaries']['completion']['size']
   send_event('es-completion-size', text: completion_size)
 end
 
@@ -35,7 +35,7 @@ count << { rate: 0, indexed: false }
 SCHEDULER.every '10s' do
   url = URI.parse "#{@es_endpoint}/_stats/indexing?human"
   response = JSON.parse Net::HTTP.get_response(url).body
-  indexed = response['indices']['pelias']['primaries']['indexing']['index_total']
+  indexed = response['indices'][@es_index]['primaries']['indexing']['index_total']
 
   # avoid huge spike with first data point
   count.last[:indexed] == false ? rate = 0 : rate = (indexed - count.last[:indexed]) / 10

--- a/jobs/include.rb
+++ b/jobs/include.rb
@@ -1,6 +1,7 @@
 # Allow specification of an elasticsearch endpoint via env var.
 #   Should take the form of "http://{ip|hostname}:{port}/{index}"
 @es_endpoint = ENV['ES_ENDPOINT'] || 'http://localhost:9200/pelias'
+@es_index = URI.split(@es_endpoint)[5].split('/').last
 
 # expected doc count
 @expected_doc_count = ENV['EXPECTED_DOC_COUNT'] || nil


### PR DESCRIPTION
Hi all,

Right now the metrics are fixed to the 'pelias'-index in Elasticsearch. This change gets the index from the ES_ENDPOINT setting so the index can be named to anything.

Another method to achieve this could be to add an extra variable ES_INDEX. But it seemed nicer to me to derive this from the current settings.

Kind regards,
Simon