### PR TITLE
Remove `AUTH_TOKEN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Basics
 
 ```
 bundle install
-AUTH_TOKEN=something ES_ENDPOINT=http://your_es_hostname_or_ip:9200/pelias dashing start
+ES_ENDPOINT=http://your_es_hostname_or_ip:9200/pelias dashing start
 ```
 
 * navigate to http://localhost:3030 in your browser

--- a/config.ru
+++ b/config.ru
@@ -1,9 +1,6 @@
 require 'dashing'
 
 configure do
-  abort 'Must set AUTH_TOKEN env var. Exiting.' unless ENV['AUTH_TOKEN']
-
-  set :auth_token,   ENV['AUTH_TOKEN']
   set :history_file, ENV['HISTORY_FILE_PATH'] || ENV['HOME'] + '/.history.yml'
 
   if File.exist?(settings.history_file)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,4 @@ services:
     hostname: pelias-dashboard
     container_name: pelias-dashboard
     environment:
-      AUTH_TOKEN: something
       ES_ENDPOINT: http://127.0.0.1:9200/pelias


### PR DESCRIPTION
This parameter is not used any more, and has caused a lot of confusion.

In the distant past, the dashboard was used at Mapzen to track progress of builds. As part of this, a Redis instance stored how many documents were seen in the _previous_ build (Mapzen had a dedicated build cluster), and used that to compare against.

The auth token was use to access this Redis instance.

Because that workflow was heavily integrated into Mapzen's infrastructure, and isn't really relevant to how we generally suggest setting up Pelias these days, it's best to remove it all.