### PR TITLE
Remove unused dashboard sections

### DIFF
--- a/dashboards/pelias.erb
+++ b/dashboards/pelias.erb
@@ -7,15 +7,7 @@
       <div data-id="types-counts" data-view="List" data-unordered="true" data-title="Counts"></div>
     </li>
 
-    <!-- build status -->
-    <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="build-status" data-view="Text" data-title="Build Status"></div>
-    </li>
-
     <!-- es metrics -->
-    <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="percent-complete" data-view="Text" data-title="Percent Complete"></div>
-    </li>
     <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
       <div data-id="es-version" data-view="Text" data-title="Elastic Version"></div>
     </li>


### PR DESCRIPTION
As mentioned in https://github.com/pelias/dashboard/pull/18, these dashboard sections rely on infrastructure set up as it was back at Mapzen, long ago.

We don't generally recommend running the dashboard on a cluster that's building, so the "build status" and "expected docs" sections are no longer relevant.