### PR TITLE
Updated docker commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ There is an included Dockerfile that can be used to run the dashboard:
 
 ```
 docker build . -t pelias/dashboard
-docker run -it -e ES_ENDPOINT=http://your_es_hostname_or_ip:9200/pelias -p 3030:3030 pelias/dashboard
+docker run -it -e ES_ENDPOINT=http://your_es_hostname_or_ip:9200/pelias -p 3030:3030 -d --restart always --name pelias_dashboard pelias/dashboard
 ```
 
 If running Pelias via [pelias/docker](https://github.com/pelias/docker/), you will want to ensure to set the correct network:
 
 ```
-docker run -it --network pelias_default -e ES_ENDPOINT=http://elasticsearch:9200/ -p 3030:3030 pelias/dashboard
+docker run -it --network pelias_default -e ES_ENDPOINT=http://elasticsearch:9200/ -p 3030:3030 -d --restart always --name pelias_dashboard pelias/dashboard
 ```


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
Was a little bit annoyed that the dashboard didn't restart after a server reboot and that all other pelias container got a name starting with pelias_

---
#### Here's what actually got changed :clap:
- [x] added the flag to start in detachted mode (`-d`)
- [x]  set the restart option to always 
- [x] gave the container a name that fits the name convention from the other container names (pelias_XXX)
